### PR TITLE
Changes to springSecurityFilterChain to prevent interference with RemoteUser

### DIFF
--- a/idp-webapp-overlay/src/main/webapp/WEB-INF/web.xml
+++ b/idp-webapp-overlay/src/main/webapp/WEB-INF/web.xml
@@ -35,7 +35,13 @@
 
     <filter-mapping>
         <filter-name>springSecurityFilterChain</filter-name>
-        <url-pattern>/*</url-pattern>
+        <url-pattern>/profile/oidc/authorize</url-pattern>
+        <url-pattern>/profile/oidc/token</url-pattern>
+        <url-pattern>/profile/oidc/userinfo</url-pattern>
+        <url-pattern>/profile/oidc/jwk</url-pattern>
+        <url-pattern>/profile/oidc/introspect</url-pattern>
+        <url-pattern>/profile/oidc/register</url-pattern>
+        <url-pattern>/profile/oidc/login</url-pattern>
     </filter-mapping>
     
     <!-- Filters and filter mappings -->


### PR DESCRIPTION
I believe that we found that the springSecurityFilterChain needed to be updated to allow the RemoteUser authentication flow.  Otherwise, you get a FlowExecutionError:

2017-10-19 12:11:00,281 - DEBUG [org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver:133] - 192.168.1.2 - Resolving exception from handler [[FlowHandlerMapping.DefaultFlowHandler@5093a762]]: org.springframework.webflow.execution.FlowExecutionException: Exception thrown in state 'doAuthenticationSubflow' of flow 'oidc/login'
2017-10-19 12:11:00,283 - ERROR [org.springframework.webflow.execution.FlowExecutionException:76] - 192.168.1.2 -
org.springframework.webflow.execution.FlowExecutionException: Exception thrown in state 'doAuthenticationSubflow' of flow 'oidc/login'
	at org.springframework.webflow.engine.impl.FlowExecutionImpl.wrap(FlowExecutionImpl.java:573)
Caused by: java.lang.IllegalArgumentException: Cannot find state with id 'RequestUnsupported' in flow 'oidc/login' -- Known state ids are 'array<String>['initializeLogin', 'clientStorageLoad', 'continueLogin', 'checkAuthenticationRequired', 'checkInitialAuthenticationRequired', 'preInitialSetup', 'doInitialAuthenticationSubflow', 'postInitialSetup', 'buildAuthenticationContext', 'doAuthenticationSubflow', 'checkResolveAttributes', 'checkForSubjectContext', 'populateSubjectContext', 'resolveAttributes', 'attributeResolution', 'doPreAuthorizeUserApprovalAction', 'doPostAuthnInterceptSubflow', 'buildResponse', 'clientStorageSave', 'doPostAuthorizeUserApprovalAction', 'redirectResponse', 'done', 'error']'
	at org.springframework.webflow.engine.Flow.getStateInstance(Flow.java:342)
2017-10-19 12:11:00,296 - DEBUG [org.springframework.web.servlet.DispatcherServlet:1208] - 192.168.1.2 - Handler execution resulted in exception - forwarding to resolved error view: ModelAndView: reference to view with name 'error'; model is {exception=org.springframework.webflow.execution.FlowExecutionException: Exception thrown in state 'doAuthenticationSubflow' of flow 'oidc/login', request=SecurityContextHolderAwareRequestWrapper[ org.springframework.security.web.context.HttpSessionSecurityContextRepository$Servlet3SaveToSessionRequestWrapper@65a99c19], encoder=class net.shibboleth.utilities.java.support.codec.HTMLEncoder, springContext=Root WebApplicationContext: startup date [Thu Oct 19 12:09:15 EDT 2017]; root of context hierarchy}
org.springframework.webflow.execution.FlowExecutionException: Exception thrown in state 'doAuthenticationSubflow' of flow 'oidc/login'
	at org.springframework.webflow.engine.impl.FlowExecutionImpl.wrap(FlowExecutionImpl.java:573)
Caused by: java.lang.IllegalArgumentException: Cannot find state with id 'RequestUnsupported' in flow 'oidc/login' -- Known state ids are 'array<String>['initializeLogin', 'clientStorageLoad', 'continueLogin', 'checkAuthenticationRequired', 'checkInitialAuthenticationRequired', 'preInitialSetup', 'doInitialAuthenticationSubflow', 'postInitialSetup', 'buildAuthenticationContext', 'doAuthenticationSubflow', 'checkResolveAttributes', 'checkForSubjectContext', 'populateSubjectContext', 'resolveAttributes', 'attributeResolution', 'doPreAuthorizeUserApprovalAction', 'doPostAuthnInterceptSubflow', 'buildResponse', 'clientStorageSave', 'doPostAuthorizeUserApprovalAction', 'redirectResponse', 'done', 'error']'
	at org.springframework.webflow.engine.Flow.getStateInstance(Flow.java:342)